### PR TITLE
feat: disable default parse mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const client = new TelegramClient(
 	env.APP_HASH,
 	{}
 )
+client.setParseMode(undefined)
 client.setLogLevel(LogLevel.NONE)
 installModules(client, modules)
 client.start({ botAuthToken: '' })


### PR DESCRIPTION
- Fixes many possible problems with formatting. If something needed parsing, the parse mode must be set manually for that.