### PR TITLE
fix: add raw opts to `CommandHandler`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ const client = new TelegramClient(
 	env.APP_HASH,
 	{}
 )
-client.setParseMode(undefined)
 client.setLogLevel(LogLevel.NONE)
 installModules(client, modules)
 client.start({ botAuthToken: '' })

--- a/src/modules/util/index.ts
+++ b/src/modules/util/index.ts
@@ -90,7 +90,9 @@ const util: Module = {
 				proc.stdin.write(input)
 				proc.stdin.end()
 			},
-			['sh', 'cmd', 'exec']
+			{
+				aliases: ['sh', 'cmd', 'exec']
+			}
 		),
 		new CommandHandler('uptime', async (_client, event) => {
 			let seconds = Math.floor(process.uptime())
@@ -123,7 +125,7 @@ const util: Module = {
 						telegramVersion
 				})
 			},
-			['v']
+			{ aliases: ['v'] }
 		),
 		new CommandHandler('whois', async (client, event, args) => {
 			let info = ''


### PR DESCRIPTION
- Merges #15 and #16 for a better solution to the inputs of the commands.
- Resets the default parse mode to MD.