### PR TITLE
fix: package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "xor",
 	"private": true,
+	"version": "0.0.1",
 	"license": "LGPL-3.0",
 	"main": "dist/index.js",
-	"version": "1.0.0-beta.1",
 	"authors": [
 		{
 			"name": "Roj",


### PR DESCRIPTION
Our first initial unstable release will be 0.0.1. The "beta/rc" identifiers will be used on unstable major versions in the future.