### PR TITLE
chore: git ignore external modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 dist/
 node_modules/
+src/externals


### PR DESCRIPTION
We don't need external modules in git repository. Prevents unwanted/accidental staging