### PR TITLE
fix: move husky to prepare script [1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
 	],
 	"scripts": {
 		"test": "ts-node src",
+		"prepare": "husky install",
 		"build": "rimraf dist && tsc",
 		"fix": "npm run lint -- --fix",
-		"postinstall": "husky install",
 		"format": "prettier --write \"src/**/*.ts\"",
 		"lint": "eslint . --ext .ts --max-warnings=0",
 		"preversion": "echo \"export const version = \\\"\"$npm_new_version\"\\\"\" > src/constants.ts"


### PR DESCRIPTION
- Suggested in [1], and fixes errors when installing with npm.

[1] https://typicode.github.io/husky/#/?id=install