### PR TITLE
feat: print object output from eval properly

### DIFF
--- a/src/modules/util/helpers.ts
+++ b/src/modules/util/helpers.ts
@@ -58,5 +58,3 @@ export async function whois(
 }
 
 export const pre = (string: string) => '<pre>' + escape(string) + '</pre>'
-
-export const printJson = (obj: object): string => JSON.stringify(obj, null, 2)

--- a/src/modules/util/helpers.ts
+++ b/src/modules/util/helpers.ts
@@ -58,3 +58,5 @@ export async function whois(
 }
 
 export const pre = (string: string) => '<pre>' + escape(string) + '</pre>'
+
+export const printJson = (obj: object): string => JSON.stringify(obj, null, 2)

--- a/src/modules/util/index.ts
+++ b/src/modules/util/index.ts
@@ -9,7 +9,7 @@ import { Module } from '../../module'
 import { wrap } from '../../helpers'
 import { version } from '../../constants'
 import { CommandHandler } from '../../handlers'
-import { pre, whois, printJson } from './helpers'
+import { pre, whois } from './helpers'
 
 const util: Module = {
 	name: 'util',
@@ -182,7 +182,6 @@ const util: Module = {
 					m: message,
 					reply,
 					r: reply,
-					print: printJson,
 					Api
 				}
 			})

--- a/src/modules/util/index.ts
+++ b/src/modules/util/index.ts
@@ -186,9 +186,14 @@ const util: Module = {
 					Api
 				}
 			})
-			const result = String(
-				await vm.run(`module.exports = (async () => {\n${input}\n})()`)
+			let result = JSON.stringify(
+				await vm.run(`module.exports = (async () => {\n${input}\n})()`),
+				null,
+				2
 			)
+			if (result.startsWith('"')) {
+				result = result.replace(/"/g, '')
+			}
 			if (result.length == 0) {
 				await event.message.edit({
 					text: event.message.text + '\n' + 'No output.'

--- a/src/modules/util/index.ts
+++ b/src/modules/util/index.ts
@@ -9,7 +9,7 @@ import { Module } from '../../module'
 import { wrap } from '../../helpers'
 import { version } from '../../constants'
 import { CommandHandler } from '../../handlers'
-import { pre, whois } from './helpers'
+import { pre, whois, printJson } from './helpers'
 
 const util: Module = {
 	name: 'util',
@@ -182,6 +182,7 @@ const util: Module = {
 					m: message,
 					reply,
 					r: reply,
+					print: printJson,
 					Api
 				}
 			})


### PR DESCRIPTION
One of the main reason of eval is working with telegram responses. And there is no builtin function in node to print an object or json object without those `[object Object]`. This PR adds a `print` function to vm2 sandbox that can log/print json/objects

ref
- https://t.me/xortest/887
- https://t.me/xortest/891
- https://nodejs.dev/learn/how-to-log-an-object-in-nodejs