### PR TITLE
chore(scripts): delete `dist` if existing

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,9 +1,12 @@
-$ARCHIVE_NAME="archive.tgz"
-$LATEST_TAG=$(Invoke-RestMethod -Uri "https://api.github.com/repos/xorgram/xor/releases/latest").tag_name
+$ARCHIVE_NAME = "archive.tgz"
+$LATEST_TAG = $(Invoke-RestMethod -Uri "https://api.github.com/repos/xorgram/xor/releases/latest").tag_name
 
 Invoke-WebRequest -Uri "https://github.com/xorgram/xor/releases/download/$LATEST_TAG/$ARCHIVE_NAME" -OutFile $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 Remove-Item $ARCHIVE_NAME
+if (Test-Path "dist") {
+  Remove-Item -LiteralPath "dist" -Force -Recurse
+}
 Copy-Item -Path "./package/*" -Destination "./" -Recurse -Force
 Remove-Item "package" -Recurse -Force
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,6 +5,7 @@ LATEST_TAG=$(wget -qO- https://api.github.com/repos/xorgram/xor/releases/latest 
 wget https://github.com/xorgram/xor/releases/download/$LATEST_TAG/$ARCHIVE_NAME -O $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 rm $ARCHIVE_NAME
+rm -rf dist
 mv package/* .
 rmdir package
 


### PR DESCRIPTION
This makes installing updates work locally.

- [x] `start.sh`
- [x] `start.ps1`