### PR TITLE
fix: xor not restarting if external module exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ async function start() {
 	)
 	manager.install(managerModule(manager), false)
 	manager.installMultiple(
-		await ModuleManager.directory(join(process.cwd(), 'externals')),
+		await ModuleManager.directory(join(__dirname, '..', 'externals')),
 		true
 	)
 	client.addEventHandler(manager.handler, new NewMessage({}))

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,10 @@ async function start() {
 		false
 	)
 	manager.install(managerModule(manager), false)
-	manager.installMultiple(await ModuleManager.directory('externals'), true)
+	manager.installMultiple(
+		await ModuleManager.directory(join(process.cwd(), 'externals')),
+		true
+	)
 	client.addEventHandler(manager.handler, new NewMessage({}))
 	await client.start({ botAuthToken: '' })
 	started = true


### PR DESCRIPTION
Currently xor can't be restarted after installing external modules due to incorrect path issues. This PR fixes this.

- [x]  Module install is working
- [x] Starting xor with pre-saved external modules working