### PR TITLE
chore: remove unused variable latest tag

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,7 +1,6 @@
 $ARCHIVE_NAME = "archive.tgz"
-$LATEST_TAG = $(Invoke-RestMethod -Uri "https://api.github.com/repos/xorgram/xor/releases/latest").tag_name
 
-Invoke-WebRequest -Uri "https://github.com/xorgram/xor/releases/download/$LATEST_TAG/$ARCHIVE_NAME" -OutFile $ARCHIVE_NAME
+Invoke-WebRequest -Uri "https://github.com/xorgram/xor/releases/download/latest/$ARCHIVE_NAME" -OutFile $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 Remove-Item $ARCHIVE_NAME
 if (Test-Path "dist") {

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,6 +1,6 @@
 $ARCHIVE_NAME = "archive.tgz"
 
-Invoke-WebRequest -Uri "https://github.com/xorgram/xor/releases/download/latest/$ARCHIVE_NAME" -OutFile $ARCHIVE_NAME
+Invoke-WebRequest -Uri "https://github.com/xorgram/xor/releases/latest/download/$ARCHIVE_NAME" -OutFile $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 Remove-Item $ARCHIVE_NAME
 if (Test-Path "dist") {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,8 +1,6 @@
 ARCHIVE_NAME=archive.tgz
-# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-LATEST_TAG=$(wget -qO- https://api.github.com/repos/xorgram/xor/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
-wget https://github.com/xorgram/xor/releases/download/$LATEST_TAG/$ARCHIVE_NAME -O $ARCHIVE_NAME
+wget https://github.com/xorgram/xor/releases/download/latest/$ARCHIVE_NAME -O $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 rm $ARCHIVE_NAME
 rm -rf dist

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 ARCHIVE_NAME=archive.tgz
 
-wget https://github.com/xorgram/xor/releases/download/latest/$ARCHIVE_NAME -O $ARCHIVE_NAME
+wget https://github.com/xorgram/xor/releases/latest/download/$ARCHIVE_NAME -O $ARCHIVE_NAME
 tar xf $ARCHIVE_NAME
 rm $ARCHIVE_NAME
 rm -rf dist


### PR DESCRIPTION
`LATEST_TAG` is not necessary to download `archive` from latest release. If you had any other plans with the variable feel free to close the PR