### PR TITLE
feat: implement security module

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,6 +1,6 @@
 import { Api, MTProtoSender, TelegramClient } from "$grm";
 
-const sensitives = [
+export const sensitives = [
   /([+]?\d{1,3}([-\s]+)?|)\d{3}([-\s]+)?\d{3}([-\s]+)?\d{4}/,
   /[0-9a-f]{32}/,
   /[0-9]{10}:[0-9A-z_-]{35}/,

--- a/client.ts
+++ b/client.ts
@@ -1,0 +1,32 @@
+import { Api, MTProtoSender, TelegramClient } from "$grm";
+
+const sensitives = [
+  /([+]?\d{1,3}([-\s]+)?|)\d{3}([-\s]+)?\d{3}([-\s]+)?\d{4}/,
+  /[0-9a-f]{32}/,
+  /[0-9]{10}:[0-9A-z_-]{35}/,
+];
+
+export const lsKey = "deactivate_security";
+
+export class Client extends TelegramClient {
+  invoke(request: Api.AnyRequest, sender?: MTProtoSender) {
+    if (!localStorage.getItem(lsKey)) {
+      let content = "";
+      if (
+        request instanceof Api.messages.EditMessage ||
+        request instanceof Api.messages.SendMessage ||
+        request instanceof Api.messages.SendMedia
+      ) {
+        content = request.message ?? "";
+      } else if (request instanceof Api.messages.SendMultiMedia) {
+        content = request.multiMedia.map((v) => v.message).join("");
+      }
+      for (const sensitive of sensitives) {
+        if (sensitive.test(content)) {
+          throw new Error("Request might contain sensitive information");
+        }
+      }
+    }
+    return super.invoke(request, sender);
+  }
+}

--- a/deps.ts
+++ b/deps.ts
@@ -5,4 +5,4 @@ export {
   num,
   str,
 } from "https://deno.land/x/envalid@v0.0.3/mod.ts";
-export * from "https://deno.land/x/grm_parse@0.0.7/mod.ts";
+export * from "https://deno.land/x/grm_parse@0.0.8/mod.ts";

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -1,12 +1,14 @@
-import { NewMessageEvent, TelegramClient } from "$grm";
+import { EditedMessageEvent, NewMessageEvent, TelegramClient } from "$grm";
 
 export const End = Symbol();
+
+export type Event = NewMessageEvent | EditedMessageEvent;
 
 export type HandleFuncResult = Promise<void | typeof End>;
 
 export interface HandlerFuncParams {
   client: TelegramClient;
-  event: NewMessageEvent;
+  event: Event;
 }
 
 export abstract class Handler {

--- a/helpers.ts
+++ b/helpers.ts
@@ -1,10 +1,11 @@
 // This file will include helpers for all modules (built-in and externals).
-import { CustomFile, NewMessageEvent, SendMessageParams } from "$grm";
+import { CustomFile, SendMessageParams } from "$grm";
 import { Buffer } from "$grm-deps";
+import { Event } from "./handlers/mod.ts";
 import { fmt, pre, type Stringable } from "./deps.ts";
 
 export function updateMessage(
-  event: NewMessageEvent,
+  event: Event,
   text: Stringable,
 ) {
   return event.message.edit(

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "$grm": "https://deno.land/x/grm@0.3.5/mod.ts",
-    "$grm-deps": "https://deno.land/x/grm@0.3.5/deps.ts",
+    "$grm": "https://deno.land/x/grm@0.3.6/mod.ts",
+    "$grm-deps": "https://deno.land/x/grm@0.3.6/deps.ts",
     "$xor": "./xor.ts",
     "pls": "https://deno.land/x/pls@1.0.0/mod.ts",
     "std/": "https://deno.land/std@0.151.0/"

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { NewMessage, StringSession } from "$grm";
+import { EditedMessage, NewMessage, StringSession } from "$grm";
 import { Client } from "./client.ts";
 import "./setup.ts";
 import env from "./env.ts";
@@ -31,5 +31,6 @@ manager.installMultiple(
   true,
 );
 client.addEventHandler(manager.handler, new NewMessage({}));
+client.addEventHandler(manager.handler, new EditedMessage({}));
 await client.start();
 log.info("started");

--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,12 @@
-import { NewMessage, StringSession, TelegramClient } from "$grm";
+import { NewMessage, StringSession } from "$grm";
+import { Client } from "./client.ts";
 import "./setup.ts";
 import env from "./env.ts";
 import modules from "./modules/mod.ts";
+import * as log from "std/log/mod.ts";
 import { managerModule, ModuleManager } from "./module_manager.ts";
 
-const client = new TelegramClient(
+const client = new Client(
   new StringSession(env.STRING_SESSION),
   env.APP_ID,
   env.APP_HASH,
@@ -29,4 +31,5 @@ manager.installMultiple(
   true,
 );
 client.addEventHandler(manager.handler, new NewMessage({}));
-client.start();
+await client.start();
+log.info("started");

--- a/module_manager.ts
+++ b/module_manager.ts
@@ -1,8 +1,8 @@
 import * as log from "std/log/mod.ts";
 import { join, resolve, toFileUrl } from "std/path/mod.ts";
-import { Api, NewMessageEvent, TelegramClient } from "$grm";
+import { Api, TelegramClient } from "$grm";
 import { bold, fmt } from "./deps.ts";
-import { CommandHandler, End } from "./handlers/mod.ts";
+import { CommandHandler, End, Event } from "./handlers/mod.ts";
 import { updateMessage } from "./helpers.ts";
 import { getHelp, isModule, Module } from "./module.ts";
 
@@ -211,7 +211,7 @@ export class ModuleManager {
     public disabled = new Set<string>(),
   ) {}
 
-  handler = async (event: NewMessageEvent) => {
+  handler = async (event: Event) => {
     for (const [, [{ name, handlers }, disableable]] of this.modules) {
       if (disableable && this.disabled.has(name)) {
         return;

--- a/modules/admin/helpers.ts
+++ b/modules/admin/helpers.ts
@@ -1,8 +1,9 @@
-import { Api, errors, NewMessageEvent, TelegramClient } from "$grm";
+import { Api, errors, TelegramClient } from "$grm";
+import { Event } from "$xor";
 import { updateMessage } from "../../helpers.ts";
 
 export const getUser = async (
-  event: NewMessageEvent,
+  event: Event,
   client: TelegramClient,
   args: string[],
   getRank = false,
@@ -73,7 +74,7 @@ export const expectedErrors: { [key: string]: string } = {
 };
 
 export async function wrapRpcErrors(
-  event: NewMessageEvent,
+  event: Event,
   func: () => Promise<void> | void,
 ) {
   try {

--- a/modules/mod.ts
+++ b/modules/mod.ts
@@ -1,7 +1,8 @@
 import admin from "./admin/mod.ts";
 import files from "./files/mod.ts";
 import util from "./util/mod.ts";
+import security from "./security/mod.ts";
 
-const modules = [admin, files, util];
+const modules = [security, admin, files, util];
 
 export default modules;

--- a/modules/security/mod.ts
+++ b/modules/security/mod.ts
@@ -1,0 +1,39 @@
+import { bold, CommandHandler, fmt, Module, updateMessage } from "$xor";
+import { lsKey } from "../../client.ts";
+
+const security: Module = {
+  name: "security",
+  handlers: [
+    new CommandHandler("sactivate", async ({ event }) => {
+      let text = "Already active.";
+      if (localStorage.getItem(lsKey)) {
+        localStorage.removeItem("deactivate_security");
+        text = "Reactivated.";
+      }
+      await updateMessage(event, text);
+    }),
+    new CommandHandler("sdeactivate", async ({ event }) => {
+      let text = "Already deactivated.";
+      if (!localStorage.getItem(lsKey)) {
+        localStorage.setItem(lsKey, "1");
+        text = "Deactivated.";
+      }
+      await updateMessage(event, text);
+    }),
+  ],
+  help: fmt`${bold("Introduction")}
+
+This module adds a request blocking layer to block requests that might contain sensitive information (e.g. phone numbers or API keys). It also deletes outgoing messages that might contain sensitive information.
+
+${bold("Commands")}
+
+> sactivate
+
+Activates the request blocking layer (activated by default).
+
+> sdeactivate
+
+Deactivates the request blocking layer.`,
+};
+
+export default security;

--- a/modules/security/mod.ts
+++ b/modules/security/mod.ts
@@ -1,4 +1,10 @@
-import { bold, CommandHandler, fmt, Module, updateMessage } from "$xor";
+import {
+  bold,
+  CommandHandler,
+  fmt,
+  Module,
+  updateMessage,
+} from "$xor";
 import { lsKey } from "../../client.ts";
 
 const security: Module = {

--- a/modules/security/mod.ts
+++ b/modules/security/mod.ts
@@ -1,9 +1,26 @@
-import { bold, CommandHandler, fmt, Module, updateMessage } from "$xor";
-import { lsKey } from "../../client.ts";
+import {
+  bold,
+  CommandHandler,
+  fmt,
+  MessageHandler,
+  Module,
+  updateMessage,
+} from "$xor";
+import * as log from "std/log/mod.ts";
+import { lsKey, sensitives } from "../../client.ts";
 
 const security: Module = {
   name: "security",
   handlers: [
+    new MessageHandler(async ({ event }) => {
+      for (const sensitive of sensitives) {
+        if (sensitive.test(event.message.message)) {
+          await event.message.delete();
+          log.warning(`deleted a sensitive message in ${event.chatId}`);
+          return;
+        }
+      }
+    }, { out: true }),
     new CommandHandler("sactivate", async ({ event }) => {
       let text = "Already active.";
       if (localStorage.getItem(lsKey)) {

--- a/modules/security/mod.ts
+++ b/modules/security/mod.ts
@@ -1,10 +1,4 @@
-import {
-  bold,
-  CommandHandler,
-  fmt,
-  Module,
-  updateMessage,
-} from "$xor";
+import { bold, CommandHandler, fmt, Module, updateMessage } from "$xor";
 import { lsKey } from "../../client.ts";
 
 const security: Module = {


### PR DESCRIPTION
The security module (enabled by default) blocks requests that might contain sensitive information before invoking them. It also deletes outgoing messages that might contain sensitive information.

Besides the security module, this PR:

- Wraps `TelegramClient` to cooperate with the security module.
- Adds a log message when the user bot starts.
- Improves MessageHandler: Fixes problems in the `out` parameter and lets handling `EditedMessageEvent`s with it.